### PR TITLE
2 administrator role is being removed from user

### DIFF
--- a/psul_user_auth.install
+++ b/psul_user_auth.install
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Install and uninstall functions for the PSUL User Auth module.
+ */
+
+/**
+ * Updates openid_connect.settings to remove administrator mapping.
+ */
+function psul_user_auth_update_10001() {
+  $config = \Drupal::configFactory()->getEditable('openid_connect.settings');
+  $role_mappings = $config->get('role_mappings');
+
+  if (isset($role_mappings['administrator']) && $role_mappings['administrator'] == ['umg-up.ul.druplars']) {
+    unset($role_mappings['administrator']);
+    $config->set('role_mappings', $role_mappings)->save();
+  }
+}

--- a/psul_user_auth.module
+++ b/psul_user_auth.module
@@ -78,6 +78,9 @@ function psul_user_auth_openid_connect_userinfo_save(UserInterface $account, arr
 
   $user_data = \Drupal::service('user.data');
 
+  // Get assigned role from userData.
+  $role_assigned = $user_data->get('psul_user_auth', $account->id(), 'admin_role_assigned');
+
   // Check if the user is in the $umg group.
   if (in_array($umg, $context['userinfo']['groups'])) {
     // Check if the user already has the administrator role.
@@ -85,14 +88,16 @@ function psul_user_auth_openid_connect_userinfo_save(UserInterface $account, arr
       // Assign the administrator role.
       $account->addRole($role);
       $account->save();
+    }
 
-      // Record that this role was assigned by the psul_user_auth module.
+    // Record that this role was assigned by the psul_user_auth module.
+    if (!$role_assigned) {
       $user_data->set('psul_user_auth', $account->id(), 'admin_role_assigned', $role);
     }
   }
 
-  // Check if the user has the administrator role, isn't in the $umg group, and the role_assignment is in the userData.
-  $role_assigned = $user_data->get('psul_user_auth', $account->id(), 'admin_role_assigned');
+  // Check if the user has the administrator role, isn't in the $umg group,
+  // and the role_assignment is in the userData.
   if ($account->hasRole($role) && !in_array($umg, $context['userinfo']['groups']) && $role_assigned === $role) {
     // Remove the administrator role.
     $account->removeRole($role);

--- a/psul_user_auth.module
+++ b/psul_user_auth.module
@@ -82,7 +82,7 @@ function psul_user_auth_openid_connect_userinfo_save(UserInterface $account, arr
   $role_assigned = $user_data->get('psul_user_auth', $account->id(), 'admin_role_assigned');
 
   // Check if the user is in the $umg group.
-  if (in_array($umg, $context['userinfo']['groups'])) {
+  if (in_array($umg, $context['userinfo']['roles'])) {
     // Check if the user already has the administrator role.
     if (!$account->hasRole($role)) {
       // Assign the administrator role.
@@ -98,7 +98,7 @@ function psul_user_auth_openid_connect_userinfo_save(UserInterface $account, arr
 
   // Check if the user has the administrator role, isn't in the $umg group,
   // and the role_assignment is in the userData.
-  if ($account->hasRole($role) && !in_array($umg, $context['userinfo']['groups']) && $role_assigned === $role) {
+  if ($account->hasRole($role) && !in_array($umg, $context['userinfo']['roles']) && $role_assigned === $role) {
     // Remove the administrator role.
     $account->removeRole($role);
     $account->save();

--- a/psul_user_auth.module
+++ b/psul_user_auth.module
@@ -5,6 +5,10 @@
  * Primary module hooks for PSUL User Auth module.
  */
 
+use Drupal\openid_connect\Entity\OpenIDConnectClientEntity;
+use Drupal\openid_connect\Plugin\OpenIDConnectClient\OpenIDConnectGenericClient;
+use Drupal\user\UserInterface;
+
 /**
  * Implements hook_openid_connect_userinfo_alter().
  *
@@ -49,4 +53,53 @@ function psul_user_auth_user_format_name_alter(&$name, $account) {
 
   // Always display the oidc_name if it is set.
   $name = $oidc_name;
+}
+
+/**
+ * Implements hook_openid_connect_userinfo_save().
+ *
+ * Assigns the administrator role to users who are in the $umg group. We're not
+ * using the role mapping in the openid_connect module because that unassigns
+ * admin roles from users who are not in the $umg group but have been manually
+ * assigned the administrator role.
+ *
+ * @see https://github.com/psu-libraries/psul_user_auth/issues/2
+ * @see https://www.drupal.org/project/openid_connect/issues/3492759
+ * @see https://git.drupalcode.org/project/openid_connect/-/merge_requests/130/diffs
+ */
+function psul_user_auth_openid_connect_userinfo_save(UserInterface $account, array $context) {
+  $client = OpenIDConnectClientEntity::load($context['plugin_id']);
+  if (!($client->getPlugin() instanceof OpenIDConnectGenericClient)) {
+    return;
+  }
+
+  $umg = 'umg-up.ul.druplars';
+  $role = 'administrator';
+
+  $user_data = \Drupal::service('user.data');
+
+  // Check if the user is in the $umg group.
+  if (in_array($umg, $context['userinfo']['groups'])) {
+    // Check if the user already has the administrator role.
+    if (!$account->hasRole($role)) {
+      // Assign the administrator role.
+      $account->addRole($role);
+      $account->save();
+
+      // Record that this role was assigned by the psul_user_auth module.
+      $user_data->set('psul_user_auth', $account->id(), 'admin_role_assigned', $role);
+    }
+  }
+
+  // Check if the user has the administrator role, isn't in the $umg group, and the role_assignment is in the userData.
+  $role_assigned = $user_data->get('psul_user_auth', $account->id(), 'admin_role_assigned');
+  if ($account->hasRole($role) && !in_array($umg, $context['userinfo']['groups']) && $role_assigned === $role) {
+    // Remove the administrator role.
+    $account->removeRole($role);
+    $account->save();
+
+    // Remove the record of role assignment from userData.
+    $user_data->delete('psul_user_auth', $account->id(), 'admin_role_assigned');
+  }
+
 }


### PR DESCRIPTION
This does 2 things.

1. Adds an update hook to remove the role mapping settings from the openid_connect module/
2. Adds the `psul_user_auth_openid_connect_userinfo_save()` hook implementation to add and remove roles from users in the `umg-up.ul.druplars` user managed group.  There is also logic to prevent the admin role from being removed from users who have be manually assigned the role in drupal.  This is done by adding a record to user_data when the administrator role is added.  