### PR TITLE
Issue #2 - Checking that userinfo roles is actually set to fix error …

### DIFF
--- a/psul_user_auth.module
+++ b/psul_user_auth.module
@@ -81,8 +81,10 @@ function psul_user_auth_openid_connect_userinfo_save(UserInterface $account, arr
   // Get assigned role from userData.
   $role_assigned = $user_data->get('psul_user_auth', $account->id(), 'admin_role_assigned');
 
+  $userinfo_roles = isset($context['userinfo']['roles']) ? $context['userinfo']['roles'] : [];
+
   // Check if the user is in the $umg group.
-  if (in_array($umg, $context['userinfo']['roles'])) {
+  if (in_array($umg, $userinfo_roles)) {
     // Check if the user already has the administrator role.
     if (!$account->hasRole($role)) {
       // Assign the administrator role.
@@ -98,7 +100,7 @@ function psul_user_auth_openid_connect_userinfo_save(UserInterface $account, arr
 
   // Check if the user has the administrator role, isn't in the $umg group,
   // and the role_assignment is in the userData.
-  if ($account->hasRole($role) && !in_array($umg, $context['userinfo']['roles']) && $role_assigned === $role) {
+  if ($account->hasRole($role) && !in_array($umg, $userinfo_roles) && $role_assigned === $role) {
     // Remove the administrator role.
     $account->removeRole($role);
     $account->save();


### PR DESCRIPTION
…for users without any roles.

Elyssa was not able to log in because she did not have any roles.  This updates the logic to check that the parameter exists and uses and empty array if it is not set.